### PR TITLE
Add Privacy Policy and Terms of Service pages

### DIFF
--- a/apps/website/index.html
+++ b/apps/website/index.html
@@ -1564,8 +1564,8 @@
                     © 2025 Candlefish AI LLC. Illuminating the path to AI transformation.
                 </p>
                 <div style="margin-top: calc(var(--grid) * 2); font-size: var(--text-sm);">
-                    <a href="https://candlefish.ai/docs/privacy" style="color: var(--text-secondary); margin-right: calc(var(--grid) * 3);">Privacy Policy</a>
-                    <a href="https://candlefish.ai/docs/terms" style="color: var(--text-secondary);">Terms of Service</a>
+                    <a href="/privacy.html" style="color: var(--text-secondary); margin-right: calc(var(--grid) * 3);">Privacy Policy</a>
+                    <a href="/terms.html" style="color: var(--text-secondary);">Terms of Service</a>
                 </div>
             </div>
         </div>

--- a/apps/website/privacy.html
+++ b/apps/website/privacy.html
@@ -1,0 +1,274 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="dark">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Privacy Policy - Candlefish AI</title>
+    <meta name="description" content="Privacy Policy for Candlefish AI LLC - How we collect, use, and protect your information.">
+    <link rel="icon" type="image/png" href="/logo/candlefish_highquality.png">
+    
+    <style>
+        :root {
+            --color-black: #000000;
+            --color-white: #FFFFFF;
+            --color-teal: #00CED1;
+            --color-gray-200: #1A1A1A;
+            --color-gray-600: #8A8A8A;
+            --color-gray-700: #AAAAAA;
+            --border-color: #3A3A3A;
+        }
+        
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+        
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+            background: var(--color-black);
+            color: var(--color-white);
+            line-height: 1.6;
+            min-height: 100vh;
+        }
+        
+        .nav {
+            position: fixed;
+            top: 0;
+            left: 0;
+            right: 0;
+            z-index: 1000;
+            padding: 1.5rem 0;
+            background: rgba(0, 0, 0, 0.9);
+            backdrop-filter: blur(10px);
+            border-bottom: 1px solid var(--border-color);
+        }
+        
+        .nav__container {
+            max-width: 1200px;
+            margin: 0 auto;
+            padding: 0 2rem;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+        }
+        
+        .nav__logo {
+            display: flex;
+            align-items: center;
+            gap: 1rem;
+            text-decoration: none;
+            color: var(--color-white);
+        }
+        
+        .nav__logo img {
+            width: 40px;
+            height: 40px;
+        }
+        
+        .nav__logo-text {
+            font-size: 1.5rem;
+            font-weight: 400;
+            letter-spacing: 0.05em;
+        }
+        
+        .nav__link {
+            color: var(--color-gray-700);
+            text-decoration: none;
+            font-size: 0.875rem;
+            letter-spacing: 0.05em;
+            transition: color 0.3s ease;
+        }
+        
+        .nav__link:hover {
+            color: var(--color-teal);
+        }
+        
+        .container {
+            max-width: 800px;
+            margin: 0 auto;
+            padding: 120px 2rem 4rem;
+        }
+        
+        h1 {
+            font-size: 3rem;
+            font-weight: 300;
+            margin-bottom: 1rem;
+            color: var(--color-teal);
+        }
+        
+        .last-updated {
+            color: var(--color-gray-600);
+            margin-bottom: 3rem;
+            font-size: 0.875rem;
+        }
+        
+        h2 {
+            font-size: 1.75rem;
+            font-weight: 400;
+            margin-top: 2.5rem;
+            margin-bottom: 1rem;
+            color: var(--color-white);
+        }
+        
+        h3 {
+            font-size: 1.25rem;
+            font-weight: 400;
+            margin-top: 1.5rem;
+            margin-bottom: 0.75rem;
+            color: var(--color-white);
+        }
+        
+        p, li {
+            color: var(--color-gray-700);
+            margin-bottom: 1rem;
+        }
+        
+        ul {
+            margin-left: 2rem;
+            margin-bottom: 1rem;
+        }
+        
+        a {
+            color: var(--color-teal);
+            text-decoration: none;
+        }
+        
+        a:hover {
+            text-decoration: underline;
+        }
+        
+        .contact-info {
+            background: var(--color-gray-200);
+            padding: 2rem;
+            border-left: 3px solid var(--color-teal);
+            margin-top: 3rem;
+        }
+    </style>
+</head>
+<body>
+    <nav class="nav">
+        <div class="nav__container">
+            <a href="/" class="nav__logo">
+                <img src="/logo/candlefish_highquality.png" alt="Candlefish AI Logo">
+                <span class="nav__logo-text">CANDLEFISH</span>
+            </a>
+            <a href="/" class="nav__link">← Back to Home</a>
+        </div>
+    </nav>
+    
+    <div class="container">
+        <h1>Privacy Policy</h1>
+        <p class="last-updated">Last Updated: January 6, 2025</p>
+        
+        <h2>Introduction</h2>
+        <p>
+            Candlefish AI LLC ("we," "our," or "us") respects your privacy and is committed to protecting your personal information. 
+            This Privacy Policy explains how we collect, use, disclose, and safeguard your information when you visit our website 
+            or use our services.
+        </p>
+        
+        <h2>Information We Collect</h2>
+        
+        <h3>Information You Provide</h3>
+        <ul>
+            <li>Contact information (name, email address, phone number, company name)</li>
+            <li>Business information relevant to our consulting services</li>
+            <li>Communications you send to us</li>
+            <li>Information provided during pilot programs or partnerships</li>
+        </ul>
+        
+        <h3>Automatically Collected Information</h3>
+        <ul>
+            <li>Device and browser information</li>
+            <li>IP address and general location data</li>
+            <li>Website usage analytics (pages visited, time spent, interactions)</li>
+            <li>Cookies and similar tracking technologies</li>
+        </ul>
+        
+        <h2>How We Use Your Information</h2>
+        <p>We use the information we collect to:</p>
+        <ul>
+            <li>Provide and improve our AI consulting services</li>
+            <li>Communicate with you about our services and partnerships</li>
+            <li>Respond to inquiries and provide customer support</li>
+            <li>Analyze and improve our website and service offerings</li>
+            <li>Comply with legal obligations</li>
+            <li>Protect against fraudulent or illegal activity</li>
+        </ul>
+        
+        <h2>Information Sharing</h2>
+        <p>
+            We do not sell, trade, or rent your personal information to third parties. We may share your information only in the 
+            following circumstances:
+        </p>
+        <ul>
+            <li>With your explicit consent</li>
+            <li>With service providers who assist in our operations (under strict confidentiality agreements)</li>
+            <li>To comply with legal obligations or respond to lawful requests</li>
+            <li>To protect our rights, property, or safety</li>
+            <li>In connection with a business transaction (merger, acquisition, or sale of assets)</li>
+        </ul>
+        
+        <h2>Data Security</h2>
+        <p>
+            We implement appropriate technical and organizational measures to protect your personal information against unauthorized 
+            access, alteration, disclosure, or destruction. However, no method of transmission over the internet or electronic 
+            storage is 100% secure.
+        </p>
+        
+        <h2>Data Retention</h2>
+        <p>
+            We retain your personal information only for as long as necessary to fulfill the purposes for which it was collected, 
+            comply with legal obligations, resolve disputes, and enforce our agreements.
+        </p>
+        
+        <h2>Your Rights</h2>
+        <p>You have the right to:</p>
+        <ul>
+            <li>Access and receive a copy of your personal information</li>
+            <li>Correct inaccurate or incomplete information</li>
+            <li>Request deletion of your personal information</li>
+            <li>Object to or restrict certain processing activities</li>
+            <li>Withdraw consent where processing is based on consent</li>
+            <li>Lodge a complaint with a supervisory authority</li>
+        </ul>
+        
+        <h2>Cookies and Tracking</h2>
+        <p>
+            We use cookies and similar tracking technologies to enhance your experience on our website. You can control cookies 
+            through your browser settings, but disabling cookies may limit your ability to use certain features of our website.
+        </p>
+        
+        <h2>Third-Party Links</h2>
+        <p>
+            Our website may contain links to third-party websites. We are not responsible for the privacy practices or content 
+            of these external sites. We encourage you to review their privacy policies.
+        </p>
+        
+        <h2>Children's Privacy</h2>
+        <p>
+            Our services are not directed to individuals under 18 years of age. We do not knowingly collect personal information 
+            from children.
+        </p>
+        
+        <h2>Changes to This Policy</h2>
+        <p>
+            We may update this Privacy Policy from time to time. We will notify you of any material changes by posting the new 
+            policy on this page and updating the "Last Updated" date.
+        </p>
+        
+        <div class="contact-info">
+            <h2>Contact Us</h2>
+            <p>
+                If you have questions or concerns about this Privacy Policy or our privacy practices, please contact us at:
+            </p>
+            <p>
+                <strong>Candlefish AI LLC</strong><br>
+                Email: hello@candlefish.ai<br>
+                Portsmouth, NH | Denver, CO
+            </p>
+        </div>
+    </div>
+</body>
+</html>

--- a/apps/website/terms.html
+++ b/apps/website/terms.html
@@ -1,0 +1,322 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="dark">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Terms of Service - Candlefish AI</title>
+    <meta name="description" content="Terms of Service for Candlefish AI LLC - Terms and conditions for using our services.">
+    <link rel="icon" type="image/png" href="/logo/candlefish_highquality.png">
+    
+    <style>
+        :root {
+            --color-black: #000000;
+            --color-white: #FFFFFF;
+            --color-teal: #00CED1;
+            --color-gray-200: #1A1A1A;
+            --color-gray-600: #8A8A8A;
+            --color-gray-700: #AAAAAA;
+            --border-color: #3A3A3A;
+        }
+        
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+        
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+            background: var(--color-black);
+            color: var(--color-white);
+            line-height: 1.6;
+            min-height: 100vh;
+        }
+        
+        .nav {
+            position: fixed;
+            top: 0;
+            left: 0;
+            right: 0;
+            z-index: 1000;
+            padding: 1.5rem 0;
+            background: rgba(0, 0, 0, 0.9);
+            backdrop-filter: blur(10px);
+            border-bottom: 1px solid var(--border-color);
+        }
+        
+        .nav__container {
+            max-width: 1200px;
+            margin: 0 auto;
+            padding: 0 2rem;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+        }
+        
+        .nav__logo {
+            display: flex;
+            align-items: center;
+            gap: 1rem;
+            text-decoration: none;
+            color: var(--color-white);
+        }
+        
+        .nav__logo img {
+            width: 40px;
+            height: 40px;
+        }
+        
+        .nav__logo-text {
+            font-size: 1.5rem;
+            font-weight: 400;
+            letter-spacing: 0.05em;
+        }
+        
+        .nav__link {
+            color: var(--color-gray-700);
+            text-decoration: none;
+            font-size: 0.875rem;
+            letter-spacing: 0.05em;
+            transition: color 0.3s ease;
+        }
+        
+        .nav__link:hover {
+            color: var(--color-teal);
+        }
+        
+        .container {
+            max-width: 800px;
+            margin: 0 auto;
+            padding: 120px 2rem 4rem;
+        }
+        
+        h1 {
+            font-size: 3rem;
+            font-weight: 300;
+            margin-bottom: 1rem;
+            color: var(--color-teal);
+        }
+        
+        .last-updated {
+            color: var(--color-gray-600);
+            margin-bottom: 3rem;
+            font-size: 0.875rem;
+        }
+        
+        h2 {
+            font-size: 1.75rem;
+            font-weight: 400;
+            margin-top: 2.5rem;
+            margin-bottom: 1rem;
+            color: var(--color-white);
+        }
+        
+        h3 {
+            font-size: 1.25rem;
+            font-weight: 400;
+            margin-top: 1.5rem;
+            margin-bottom: 0.75rem;
+            color: var(--color-white);
+        }
+        
+        p, li {
+            color: var(--color-gray-700);
+            margin-bottom: 1rem;
+        }
+        
+        ul, ol {
+            margin-left: 2rem;
+            margin-bottom: 1rem;
+        }
+        
+        a {
+            color: var(--color-teal);
+            text-decoration: none;
+        }
+        
+        a:hover {
+            text-decoration: underline;
+        }
+        
+        .contact-info {
+            background: var(--color-gray-200);
+            padding: 2rem;
+            border-left: 3px solid var(--color-teal);
+            margin-top: 3rem;
+        }
+        
+        .important-notice {
+            background: var(--color-gray-200);
+            border: 1px solid var(--color-teal);
+            padding: 1.5rem;
+            margin: 2rem 0;
+        }
+    </style>
+</head>
+<body>
+    <nav class="nav">
+        <div class="nav__container">
+            <a href="/" class="nav__logo">
+                <img src="/logo/candlefish_highquality.png" alt="Candlefish AI Logo">
+                <span class="nav__logo-text">CANDLEFISH</span>
+            </a>
+            <a href="/" class="nav__link">← Back to Home</a>
+        </div>
+    </nav>
+    
+    <div class="container">
+        <h1>Terms of Service</h1>
+        <p class="last-updated">Last Updated: January 6, 2025</p>
+        
+        <div class="important-notice">
+            <p><strong>IMPORTANT:</strong> These Terms of Service ("Terms") govern your use of Candlefish AI LLC's website and services. 
+            By accessing or using our services, you agree to be bound by these Terms.</p>
+        </div>
+        
+        <h2>1. Acceptance of Terms</h2>
+        <p>
+            By accessing or using the services provided by Candlefish AI LLC ("Company," "we," "our," or "us"), you agree to 
+            comply with and be bound by these Terms of Service. If you do not agree with these Terms, please do not use our services.
+        </p>
+        
+        <h2>2. Services Description</h2>
+        <p>
+            Candlefish AI provides enterprise AI consulting services, including but not limited to:
+        </p>
+        <ul>
+            <li>AI implementation and integration</li>
+            <li>Business process automation</li>
+            <li>Data analysis and optimization</li>
+            <li>Custom AI solution development</li>
+            <li>Pilot program partnerships</li>
+        </ul>
+        
+        <h2>3. Use of Services</h2>
+        
+        <h3>Eligibility</h3>
+        <p>
+            Our services are available only to businesses and individuals who can form legally binding contracts under applicable law. 
+            You must be at least 18 years old to use our services.
+        </p>
+        
+        <h3>Acceptable Use</h3>
+        <p>You agree to use our services only for lawful purposes and in accordance with these Terms. You agree not to:</p>
+        <ul>
+            <li>Violate any applicable laws or regulations</li>
+            <li>Infringe upon intellectual property rights</li>
+            <li>Transmit malicious code or interfere with our services</li>
+            <li>Attempt unauthorized access to our systems</li>
+            <li>Misrepresent your identity or affiliation</li>
+            <li>Use our services for competitive analysis without permission</li>
+        </ul>
+        
+        <h2>4. Intellectual Property</h2>
+        
+        <h3>Our Property</h3>
+        <p>
+            All content, features, and functionality of our website and services, including but not limited to text, graphics, 
+            logos, and software, are owned by Candlefish AI LLC and protected by intellectual property laws.
+        </p>
+        
+        <h3>Client Property</h3>
+        <p>
+            You retain all rights to your data and content provided to us. By providing content to us, you grant us a limited 
+            license to use, process, and analyze such content solely for the purpose of providing our services.
+        </p>
+        
+        <h3>Deliverables</h3>
+        <p>
+            Ownership of deliverables created as part of our services will be specified in separate agreements. Unless otherwise 
+            agreed in writing, you will own all deliverables upon full payment.
+        </p>
+        
+        <h2>5. Confidentiality</h2>
+        <p>
+            Both parties agree to maintain the confidentiality of any proprietary or sensitive information shared during the 
+            course of our engagement. This obligation survives the termination of these Terms.
+        </p>
+        
+        <h2>6. Payment Terms</h2>
+        <p>
+            Payment terms, including fees, invoicing, and payment schedules, will be specified in separate service agreements 
+            or statements of work. Late payments may incur additional charges as specified in such agreements.
+        </p>
+        
+        <h2>7. Disclaimers and Warranties</h2>
+        
+        <h3>No Warranty</h3>
+        <p>
+            OUR SERVICES ARE PROVIDED "AS IS" AND "AS AVAILABLE" WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED. 
+            WE DISCLAIM ALL WARRANTIES, INCLUDING BUT NOT LIMITED TO IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A 
+            PARTICULAR PURPOSE, AND NON-INFRINGEMENT.
+        </p>
+        
+        <h3>No Guarantee</h3>
+        <p>
+            We do not guarantee specific results from our services. While we strive for excellence, outcomes may vary based 
+            on numerous factors beyond our control.
+        </p>
+        
+        <h2>8. Limitation of Liability</h2>
+        <p>
+            IN NO EVENT SHALL CANDLEFISH AI LLC BE LIABLE FOR ANY INDIRECT, INCIDENTAL, SPECIAL, CONSEQUENTIAL, OR PUNITIVE 
+            DAMAGES, INCLUDING WITHOUT LIMITATION, LOSS OF PROFITS, DATA, USE, GOODWILL, OR OTHER INTANGIBLE LOSSES, ARISING 
+            FROM YOUR USE OF OUR SERVICES.
+        </p>
+        <p>
+            OUR TOTAL LIABILITY SHALL NOT EXCEED THE AMOUNT PAID BY YOU FOR THE SERVICES IN THE TWELVE (12) MONTHS PRECEDING 
+            THE EVENT GIVING RISE TO LIABILITY.
+        </p>
+        
+        <h2>9. Indemnification</h2>
+        <p>
+            You agree to indemnify, defend, and hold harmless Candlefish AI LLC, its officers, directors, employees, and agents 
+            from any claims, damages, losses, liabilities, and expenses (including reasonable attorney's fees) arising from your 
+            use of our services or violation of these Terms.
+        </p>
+        
+        <h2>10. Termination</h2>
+        <p>
+            Either party may terminate these Terms at any time with written notice. Upon termination, your right to use our 
+            services will immediately cease. Provisions that by their nature should survive termination shall survive.
+        </p>
+        
+        <h2>11. Governing Law</h2>
+        <p>
+            These Terms shall be governed by and construed in accordance with the laws of the State of New Hampshire, without 
+            regard to its conflict of law provisions. Any disputes shall be resolved in the courts of New Hampshire.
+        </p>
+        
+        <h2>12. Changes to Terms</h2>
+        <p>
+            We reserve the right to modify these Terms at any time. We will notify you of any material changes by posting the 
+            new Terms on our website. Your continued use of our services after such modifications constitutes acceptance of the 
+            updated Terms.
+        </p>
+        
+        <h2>13. Severability</h2>
+        <p>
+            If any provision of these Terms is found to be unenforceable or invalid, that provision shall be limited or eliminated 
+            to the minimum extent necessary, and the remaining provisions shall remain in full force and effect.
+        </p>
+        
+        <h2>14. Entire Agreement</h2>
+        <p>
+            These Terms, together with any separate service agreements, constitute the entire agreement between you and Candlefish 
+            AI LLC regarding the use of our services and supersede all prior agreements and understandings.
+        </p>
+        
+        <div class="contact-info">
+            <h2>Contact Information</h2>
+            <p>
+                For questions about these Terms of Service, please contact us at:
+            </p>
+            <p>
+                <strong>Candlefish AI LLC</strong><br>
+                Email: hello@candlefish.ai<br>
+                Portsmouth, NH | Denver, CO
+            </p>
+        </div>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
Created legal pages as requested:
- Added comprehensive Privacy Policy page at /privacy.html
- Added comprehensive Terms of Service page at /terms.html
- Updated footer links to point to actual pages instead of 404s
- Both pages use consistent dark theme styling matching the main site